### PR TITLE
feat: restrict access to stable coin pages when PLT feature is disabled

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -9,36 +9,38 @@ export default defineNuxtConfig({
 			version: process.env.npm_package_version,
 			// URL to use when sending GraphQL queries to the CCDscan API.
 			// (env NUXT_PUBLIC_API_URL)
-			apiUrl: 'https://api-ccdscan.mainnet.concordium.software/graphql',
+			apiUrl: process.env.NUXT_PUBLIC_API_URL,
 			// URL to use when using websockets in GraphQL CCDscan API.
 			// (env NUXT_PUBLIC_WS_URL)
-			wsUrl: 'wss://api-ccdscan.mainnet.concordium.software/graphql',
+			wsUrl: process.env.NUXT_PUBLIC_WS_URL,
 			// URL to use when sending GraphQL queries to the CCDscan API.
 			// (env NUXT_PUBLIC_API_URL_RUST)
-			apiUrlRust: 'http://localhost:8000/api/graphql',
+			apiUrlRust: process.env.NUXT_PUBLIC_API_URL_RUST,
 			// URL to use when using websockets in GraphQL CCDscan API.
 			// (env NUXT_PUBLIC_WS_URL_RUST)
-			wsUrlRust: 'ws://localhost:8000/api/graphql',
+			wsUrlRust: process.env.NUXT_PUBLIC_WS_URL_RUST,
 			// Settings for how to display the explorer.
 			explorer: {
 				// The name to display for the explorer.
 				// (env NUXT_PUBLIC_EXPLORER_NAME)
-				name: 'Local',
+				name: process.env.NUXT_PUBLIC_EXPLORER_NAME,
 				// The list of external explorers to link in the explorer selector.
 				// Should be provided as `<name>@<url>` separated by `;`.
 				// Ex.: 'Mainnet@https://ccdscan.io;Testnet@https://testnet.ccdscan.io'
 				// (env NUXT_PUBLIC_EXPLORER_EXTERNAL).
-				external:
-					'Mainnet@https://ccdscan.io;Testnet@https://testnet.ccdscan.io;Stagenet@https://stagenet.ccdscan.io',
+				external: process.env.NUXT_PUBLIC_EXPLORER_EXTERNAL,
 			},
 			// When enabled a hint for the current breakpoint (related to screen size)
 			// is displayed in the bottom left corner. Enable only for development.
 			// (env NUXT_PUBLIC_ENABLE_BREAKPOINT_HINT)
-			enableBreakpointHint: false,
+			enableBreakpointHint: process.env.NUXT_PUBLIC_ENABLE_BREAKPOINT_HINT,
 			// Enabled the urql-devtools for debugging GraphQL (require browser extension).
 			// Enable only for development.
 			// (env NUXT_PUBLIC_ENABLE_URQL_DEVTOOLS)
-			enableUrqlDevtools: false,
+			enableUrqlDevtools: process.env.NUXT_PUBLIC_ENABLE_URQL_DEVTOOLS,
+
+			//Environment config for stable coin menu display
+			enablePltFeatures: process.env.NUXT_PUBLIC_ENABLE_PLT_FEATURES,
 		},
 	},
 	// Directory for finding the source files.

--- a/frontend/src/components/Navigation/Navigation.vue
+++ b/frontend/src/components/Navigation/Navigation.vue
@@ -11,7 +11,11 @@ import MobileNavigation from './MobileNavigation.vue'
 import DesktopNavigation from './DesktopNavigation.vue'
 import type { Route } from '~/types/route'
 
-const routes: Route[] = [
+const {
+	public: { enablePltFeatures },
+} = useRuntimeConfig()
+
+const allRoutes: Route[] = [
 	{
 		title: 'Home',
 		path: '/',
@@ -49,4 +53,9 @@ const routes: Route[] = [
 		path: '/stable-coin',
 	},
 ]
+
+// Now, filter it based on env
+const routes = enablePltFeatures
+	? allRoutes
+	: allRoutes.filter(route => route.title !== 'Stable Coin')
 </script>

--- a/frontend/src/middleware/plt-features-guard.ts
+++ b/frontend/src/middleware/plt-features-guard.ts
@@ -1,0 +1,9 @@
+export default defineNuxtRouteMiddleware(to => {
+	const {
+		public: { enablePltFeatures },
+	} = useRuntimeConfig()
+
+	if (!enablePltFeatures && to.path.startsWith('/stable-coin')) {
+		return navigateTo('/') // Redirect to home or show 404
+	}
+})

--- a/frontend/src/pages/stable-coin/[stablecoin].vue
+++ b/frontend/src/pages/stable-coin/[stablecoin].vue
@@ -112,6 +112,10 @@ import Analytics from '~/components/StableCoin/Analytics.vue'
 import { useRoute } from 'vue-router'
 const route = useRoute()
 
+definePageMeta({
+	middleware: 'plt-features-guard',
+})
+
 const coinId = computed(() => {
 	const id = route.params.stablecoin
 	return Array.isArray(id) ? id[0] : id || ''

--- a/frontend/src/pages/stable-coin/index.vue
+++ b/frontend/src/pages/stable-coin/index.vue
@@ -106,6 +106,10 @@ import StableCoinDistributionChart from '~/components/molecules/ChartCards/Stabl
 import StableCoinSupplyBarChart from '~/components/molecules/ChartCards/StableCoinSupplyBarChart.vue'
 import HolderByStableCoin from '~/components/molecules/ChartCards/HolderByStableCoin.vue'
 
+definePageMeta({
+	middleware: 'plt-features-guard',
+})
+
 const { data: stableCoinsData } = useStableCoinsQuery()
 
 const { data: overviewData } = useStablecoinOverviewQuery()


### PR DESCRIPTION
- Added a middleware `plt-features-guard` to protect stable coin routes.
- Filtered out the "Stable Coin" route when PLT features are disabled.
- Ensured users cannot access stable coin pages directly via URL.